### PR TITLE
Add correct proprietary Copyright notice

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,22 +1,7 @@
-Copyright (c) 2014 Wojciech Ogrodowczyk
+The following copyright and license notice apply to individual files and any files under the directories provided at the end of this notice.
 
-MIT License
+Copyright 2017 Red Hat, Inc. and/or its affiliates. All rights reserved. 
+For terms of use, please refer to your End User License Agreement and/or other agreements that may have been provided to you governing the use of this software.   
 
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+/lib
+/test


### PR DESCRIPTION
Although the LICENSE.txt file's original text was MIT, this repo remains private and the gem was never published outside of 3scale.

Until we open source all later the correct Red Hat copyright should be included and a reference to the files with the copyrighted source.